### PR TITLE
Feature-firebase-auth

### DIFF
--- a/src/components/FormInputSection.jsx
+++ b/src/components/FormInputSection.jsx
@@ -1,0 +1,26 @@
+
+export const FormInputs = ({ inputs, onBlur }) => {
+    return inputs.map(({ type, name, placeholder, options, value, disabled, onBlur: onBlurOverride }) => (
+      type === 'select' ||   (options && options.length > 0) ? (
+        <select
+          name={name}
+          value={value}
+          disabled={disabled}
+          key={name}
+          onChange={onBlurOverride?? onBlur}
+        >
+          {options.map(({ value, label }) => (
+            <option value={value} key={value}>{label}</option>
+          ))}
+        </select>
+      ) : <input
+        type={type}
+        name={name}
+        placeholder={placeholder}
+        value={value}
+        disabled={disabled}
+        key={name}
+        onChange={onBlurOverride ?? onBlur}
+      />
+    ));
+  }

--- a/src/components/JobCard.jsx
+++ b/src/components/JobCard.jsx
@@ -1,15 +1,16 @@
 // src/components/JobCard.jsx
 import '../styles/JobCard.css';
+import PropTypes from 'prop-types'
 
-const JobCard = (props) => {
+const JobCard = ({ job }) => {
   return (
     <div className="job-card">
-      <h3>{props.job.title}</h3>
-      <p>Description: {props.job.description}</p>
-      <p>Budget: {props.job.budget}</p>
-      <p>Created: {props.job.createdAt}</p>
-      <p>Client ID: {props.job.clientId}</p>
-      <p>ID: {props.job.id}</p>
+      <h3>{job.title}</h3>
+      <p>Description: {job.description}</p>
+      <p>Budget: {job.budget}</p>
+      <p>Created: {job.createdAt}</p>
+      <p>Client ID: {job.clientId}</p>
+      <p>ID: {job.id}</p>
     </div>
   );
 };

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,10 +1,16 @@
 // src/components/Navbar.jsx
 import { Link } from 'react-router-dom';
 import logo from '../assets/bwlogo1.png';
-
+import { useUser } from '../hooks/useUser'
 import '../styles/Navbar.css';
 
 const Navbar = () => {
+  const [user, setUser] = useUser();
+
+  const onLogoutClick = () => {
+    setUser(null)
+  }
+
   return (
     <nav className="navbar">
       <div className="nav-logo">
@@ -15,8 +21,9 @@ const Navbar = () => {
       <ul className="nav-links">
         <li><Link to="/find-talent">Find Talent</Link></li>
         <li><Link to="/find-work">Find Work</Link></li>
-        <li><button className="btn btn-login"><Link to="/login">Log In</Link></button></li>
-        <li><button className="btn btn-signup"><Link to="/signup">Sign Up</Link></button></li>
+        {!user?.email && <li><button className="btn btn-login"><Link to="/login">Log In</Link></button></li>}
+        {!user?.email && <li><button className="btn btn-signup"><Link to="/signup">Sign Up</Link></button></li>}
+        {user?.email && <li><button onClick={onLogoutClick} className="btn btn-login">Sign Out</button></li>}
       </ul>
     </nav>
   );

--- a/src/components/ResponseLabel.jsx
+++ b/src/components/ResponseLabel.jsx
@@ -1,0 +1,9 @@
+import { getBoxStyles } from '../utils/styleUtils'
+
+// eslint-disable-next-line react/prop-types
+const ResponseLabel = ({ type, children }) => {
+    const labelJss = getBoxStyles(type)
+    return <p style={labelJss}>{children}</p>
+}
+
+export default ResponseLabel

--- a/src/config/firebaseConfig.json
+++ b/src/config/firebaseConfig.json
@@ -1,0 +1,9 @@
+{
+    "apiKey": "AIzaSyAPYh8ClinGUAH2Yp7WgpQAbFt6P9JjYhU",
+    "authDomain": "better-work-2bd59.firebaseapp.com",
+    "projectId": "better-work-2bd59",
+    "storageBucket": "better-work-2bd59.firebasestorage.app",
+    "messagingSenderId": "531626822870",
+    "appId": "1:531626822870:web:1be8ff15fb913dcaf8cd77",
+    "measurementId": "G-Y0VP9329BJ"
+  }

--- a/src/hooks/useUser.js
+++ b/src/hooks/useUser.js
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+import { UserDataObserver } from '../services/firebase'
+
+export function useUser() {
+    const [user, setUser] = useState(null);
+  
+    useEffect(() => {
+        const unsubscribe = new UserDataObserver()
+            .authorized(currentUser => setUser(currentUser))
+            .unauthorized(() => setUser(null))
+            .subscribe()
+        return () => unsubscribe();
+    }, []);
+  
+    return [user, setUser];
+}

--- a/src/pages/Login.content.json
+++ b/src/pages/Login.content.json
@@ -1,0 +1,15 @@
+{
+  "title": "Login",
+  "messages": {
+    "success": "Successfully logged in as "
+  },
+  "inputs": [{
+    "type": "email",
+    "name": "email",
+    "placeholder": "Email"
+  }, {
+    "type": "password",
+    "name": "password",
+    "placeholder": "Password"
+  }]
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,37 +1,62 @@
 import { useState } from 'react';
-import { login } from '../services/apiService';
+import { useUser } from '../hooks/useUser';
+import { loginUser } from '../services/firebase';
+import { FormInputs } from "../components/FormInputSection"
+import { title, inputs, messages } from "./Login.content.json"
+import ResponseLabel from '../components/ResponseLabel'
+import { FormSubmitJob } from '../utils/formUtils'
 import styles from './Login.module.css'; // Import CSS module
 
 const Login = () => {
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState(false);
+  const [error, setError] = useState(false);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [user, setUser] = useUser();
 
-  const handleLogin = async () => {
-    try {
-      const response = await login(email, password);
-      console.log(response.data);
-    } catch (error) {
-      console.error('Login failed', error);
-    }
-  };
+  const onBlur = (e) => {
+    console.log(e.target.form)
+    const formData = new FormData(e.target.form)
+    const formEmail = formData.get("email")
+    const formPw = formData.get("password")
+    if(email != formEmail) setEmail(formEmail)
+    if(formPw != password) setPassword(formPw)
+  }
+  /**
+   * Example of integration with a frontend login page.
+   */
+  async function handleServerlessLogin() {
+    const response =  await loginUser(email, password);
+    return response
+  }
 
+  async function handleSumbit (e) {
+    setUser(await new FormSubmitJob(e)
+      .formAction(handleServerlessLogin)
+      .fail(setError)
+      .loadingStateChanged(setLoading)
+      .serverMessage(setMessage)
+      .submit())
+  }
+  // const handleLogin = async () => {
+  //   try {
+  //     const response = await login(email, password);
+  //     console.log(response.data);
+  //   } catch (error) {
+  //     console.error('Login failed', error);
+  //   }
+  // };
   return (
-    <div className={styles.loginContainer}>
-      <h1>Log In</h1>
-      <input
-        type="email"
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-      />
-      <input
-        type="password"
-        placeholder="Password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-      />
-      <button onClick={handleLogin}>Log In</button>
-    </div>
+    <form onSubmit={handleSumbit} className={styles.loginContainer}>
+      <h1>{title}</h1>
+      {message && <ResponseLabel>{message}</ResponseLabel>}
+      {error && <ResponseLabel type={'error'}>{error}</ResponseLabel>}
+      {!loading && user?.firstName 
+        ? <ResponseLabel>{messages.success} {user.firstName} {user.lastName}</ResponseLabel>
+        : <FormInputs {...{ inputs, onBlur }}/>}
+      <button disabled={user} type="submit">{title}</button>
+    </form>
   );
 };
 

--- a/src/pages/Signup.content.json
+++ b/src/pages/Signup.content.json
@@ -1,0 +1,36 @@
+{
+  "title": "Sign Up",
+  "inputs": [{
+    "type": "text",
+    "name": "firstName",
+    "placeholder": "First Name",
+    "required": true
+  }, {
+    "type": "text",
+    "name": "lastName",
+    "placeholder": "Last Name",
+    "required": true
+  }, {
+    "type": "text",
+    "name": "address",
+    "placeholder": "Address"
+  }, {
+    "type": "text",
+    "name": "phoneNumber",
+    "placeholder": "Phone Number"
+  }, {
+    "type": "email",
+    "name": "email",
+    "placeholder": "Email"
+  }, {
+    "type": "password",
+    "name": "password",
+    "placeholder": "Password"
+  }, {
+    "type": "select",
+    "name": "role",
+    "placeholder": "Role (Freelancer/Employer)",
+    "options": [{ "value": "Freelancer", "label": "Freelancer" }, { "value": "Client", "label": "Client" }],
+    "disabled": true
+  }]
+}

--- a/src/services/firebase.js
+++ b/src/services/firebase.js
@@ -1,21 +1,110 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "firebase/app";
 import { getAnalytics } from "firebase/analytics";
+import { getAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword } from "firebase/auth";
+import { getFirestore, doc, setDoc, getDoc } from "firebase/firestore";
+import firebaseConfig from '../config/firebaseConfig.json'
+
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 
 // Your web app's Firebase configuration
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
-const firebaseConfig = {
-  apiKey: "AIzaSyAPYh8ClinGUAH2Yp7WgpQAbFt6P9JjYhU",
-  authDomain: "better-work-2bd59.firebaseapp.com",
-  projectId: "better-work-2bd59",
-  storageBucket: "better-work-2bd59.firebasestorage.app",
-  messagingSenderId: "531626822870",
-  appId: "1:531626822870:web:1be8ff15fb913dcaf8cd77",
-  measurementId: "G-Y0VP9329BJ"
-};
-
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
 const analytics = getAnalytics(app);
+analytics
+const auth = getAuth(app);
+const db = getFirestore(app);
+
+/**
+ * Registers a new user with email and password.
+ * @param {string} email - The user's email.
+ * @param {string} password - The user's password.
+ * @returns {Promise<Object>} User data or error message.
+ */
+export async function registerUser(email, password) {
+  try {
+    const userCredential = await createUserWithEmailAndPassword(auth, email, password);
+    const user = userCredential.user;
+
+    // Save user data to Firestore
+    await setDoc(doc(db, "users", user.uid), {
+      email: user.email,
+      createdAt: new Date().toISOString(),
+    });
+
+    return { uid: user.uid, email: user.email };
+  } catch (error) {
+    return { error: error.message };
+  }
+}
+
+/**
+ * Logs in a user with email and password.
+ * @param {string} email - The user's email.
+ * @param {string} password - The user's password.
+ * @returns {Promise<Object>} User data or error message.
+ */
+export async function loginUser(email, password) {
+  try {
+    const userCredential = await signInWithEmailAndPassword(auth, email, password);
+    const user = userCredential.user;
+
+    // Retrieve additional user data from Firestore
+    const userDoc = await getDoc(doc(db, "users", user.uid));
+    const userData = userDoc.data();
+
+    return { uid: user.uid, email: user.email, ...userData };
+  } catch (error) {
+    return { error: error.message };
+  }
+}
+
+/**
+ * Validates the current JWT token for the authenticated user.
+ * @returns {Promise<Object>} User data or error message.
+ */
+export async function validateJWT() {
+  try {
+    const user = auth.currentUser;
+
+    if (!user) {
+      throw new Error("No authenticated user found.");
+    }
+
+    const idToken = await user.getIdToken();
+    return { uid: user.uid, email: user.email, idToken };
+  } catch (error) {
+    return { error: error.message };
+  }
+}
+
+export class UserDataObserver {
+  userData;
+  success;
+  fail;
+  authorized = (callback) => {
+    this.success = callback
+    return this;
+  }
+  unauthorized =(callback) => {
+    this.fail = callback
+    return this;
+  }
+  subscribe = () => {
+    return auth.onAuthStateChanged(async (currentUser) => {
+      if (currentUser) {
+        const doc = doc(db, "users", currentUser.uid)
+        const userDoc = await getDoc(doc);
+        this.userData = userDoc.data();
+        this.authorized(this.userData)
+        return this.userData
+      } else {
+        this.userData = null
+        this.unauthorized(null);
+        return null
+      }
+  })
+}
+}

--- a/src/utils/formUtils.js
+++ b/src/utils/formUtils.js
@@ -1,0 +1,60 @@
+export const getEventFormData = (form) => { 
+    const updatedFormData = {}
+    const inputData = new FormData(form)
+    inputData.keys().forEach(key => {
+      console.log(inputData.get(key))
+      updatedFormData[key] = inputData.get(key)
+    })
+    return updatedFormData
+}
+
+export class FormSubmitJob {
+   failCallback
+   loadingCallback
+   messageCallback
+   actionCallback
+   formData
+   constructor(e) {
+    e.preventDefault()
+    this.readEventData(e)
+   }
+   readEventData = (e) => {
+    this.formData = getEventFormData(e.target.form)
+   }
+   formAction = (callback) => {
+    this.actionCallback = callback
+    return this
+   }
+   fail = (callback) => {
+    this.failCallback = callback
+    return this
+   }
+   loadingStateChanged = (callback) => {
+    this.loadingCallback = callback
+    return this
+   }
+   serverMessage = (callback) => {
+    this.messageCallback = callback
+    return this
+   }
+   submit = async () => {
+    try {
+      this.loadingCallback(true)
+      alert(JSON.stringify(this.formData))
+      const response = await this.actionCallback(this.formData);
+      if(!response) {
+        this.failCallback("Response undefined.")
+      }
+      if(response?.error) {
+        this.failCallback(response?.error)
+      } else {
+        this.messageCallback(JSON.stringify(response));
+      }
+    } catch (error) {
+      console.error(error.message);
+      this.failCallback(error.message)
+    } finally {
+      this.loadingCallback(false)
+    }
+  }
+}

--- a/src/utils/styleUtils.js
+++ b/src/utils/styleUtils.js
@@ -1,0 +1,6 @@
+export const getBoxStyles = (type) => ({
+    background: type === 'error' ? 'rgba(255, 0, 0, .30)' : 'rgba(0, 255, 0, .1)',
+    color: type === 'error' ? 'darkred' : 'green',
+    border: type === 'error' ? '2px darkred solid' : '2px green solid',
+    padding: "16px"
+})


### PR DESCRIPTION
Implemented serverless firebase auth. Needs permession from the firebase console.

The "operation not allowed" error typically occurs in Firebase when the authentication method you're trying to use is not enabled in the Firebase Console. To resolve this issue, follow these steps:

Steps to Enable Authentication Methods
Go to Firebase Console:

Navigate to Firebase Console.
Select Your Project:

Click on the project you are working on.
Go to Authentication Settings:

In the left-hand menu, click on Authentication under the Build section.
Enable Sign-In Methods:

In the Sign-in method tab, you'll see a list of supported providers (e.g., Email/Password, Google, etc.).
Click on the pencil/edit icon next to the Email/Password method and enable it if it's disabled.
Save Changes:

After enabling the method, click Save.
Check Your Code:

Ensure the authentication method you're using in the code matches the enabled methods in Firebase Console.
Additional Debugging Tips
Error Details: Check the error object returned from Firebase for more details, including an error code (e.g., auth/operation-not-allowed).
Rules Configuration: If the error relates to Firestore, ensure the database rules allow the operation. You can find them under Firestore Database > Rules.
Deployment: Ensure that your Firebase project is correctly initialized with the configuration details.
Let me know if you continue facing issues, and we can debug further!